### PR TITLE
Fix CopyWebpackPlugin & JS template

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,11 @@ module.exports = {
         Atomics: "readonly",
         SharedArrayBuffer: "readonly"
     },
+    overrides: [
+        {
+            files: [".js", ".ts"]
+        }
+    ],
     parser: "@typescript-eslint/parser",
     parserOptions: {
         project: "tsconfig.all.json",
@@ -51,7 +56,8 @@ module.exports = {
         "node/no-missing-require": [
             "error",
             {
-                tryExtensions: [".ts", ".js", ".d.ts", ".json", ".node"]
+                tryExtensions: [".ts", ".js", ".d.ts", ".json", ".node"],
+                allowModules: ["clean-webpack-plugin", "copy-webpack-plugin"]
             }
         ],
         "node/no-missing-import": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "create-windowless-app",
-    "version": "3.1.2",
+    "version": "3.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -7393,9 +7393,9 @@
             "dev": true
         },
         "ts-jest": {
-            "version": "25.5.1",
-            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-25.5.1.tgz",
-            "integrity": "sha512-kHEUlZMK8fn8vkxDjwbHlxXRB9dHYpyzqKIGDNxbzs+Rz+ssNDSDNusEK8Fk/sDd4xE6iKoQLfFkFVaskmTJyw==",
+            "version": "26.0.0",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.0.0.tgz",
+            "integrity": "sha512-eBpWH65mGgzobuw7UZy+uPP9lwu+tPp60o324ASRX4Ijg8UC5dl2zcge4kkmqr2Zeuk9FwIjvCTOPuNMEyGWWw==",
             "dev": true,
             "requires": {
                 "bs-logger": "0.x",
@@ -7405,15 +7405,15 @@
                 "lodash.memoize": "4.x",
                 "make-error": "1.x",
                 "micromatch": "4.x",
-                "mkdirp": "0.x",
-                "semver": "6.x",
+                "mkdirp": "1.x",
+                "semver": "7.x",
                 "yargs-parser": "18.x"
             },
             "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+                    "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
                     "dev": true
                 }
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "create-windowless-app",
-    "version": "3.1.2",
+    "version": "3.2.0",
     "description": "Create a windowless NodeJS app",
     "main": "dist/index.js",
     "bin": {
@@ -8,7 +8,7 @@
     },
     "scripts": {
         "build": "npm run eslint && npm run test && npm run tsc && npm run package",
-        "eslint": "eslint src/**/*.ts test/**/*.ts",
+        "eslint": "eslint src/ test/ templates/",
         "eslint:fix": "npm run eslint -- --fix",
         "prettier": "prettier --write *.json templates/**/*.json",
         "test": "jest --coverage",
@@ -74,7 +74,7 @@
         "node-notifier": "7.0.0",
         "prettier": "2.0.5",
         "rimraf": "3.0.2",
-        "ts-jest": "25.5.1",
+        "ts-jest": "26.0.0",
         "ts-node": "8.10.1",
         "typescript": "3.9.2",
         "uuid": "8.0.0",

--- a/templates/javascript/launcher/launcherCompiler.js
+++ b/templates/javascript/launcher/launcherCompiler.js
@@ -9,9 +9,10 @@ const checkCscInPath = async (exit) => {
     const cscFound = await results.find((result) => !!result);
 
     if (exit && !cscFound) {
-        console.error(`You need "csc.exe" (C# compiler) in your path in order to compile the launcher.exe.`);
+        console.error("You need \"csc.exe\" (C# compiler) in your path in order to compile the launcher.exe.");
         process.exit(1);
-    } else {
+    }
+    else {
         return cscFound;
     }
 };

--- a/templates/javascript/src/index.js
+++ b/templates/javascript/src/index.js
@@ -1,6 +1,7 @@
 const path = require("path");
 const winston = require("winston");
 const { WindowsToaster } = require("node-notifier");
+const { execFile } = require("child_process");
 
 // App Name
 const AppName = "<APPNAME>";

--- a/templates/javascript/webpack.config.js
+++ b/templates/javascript/webpack.config.js
@@ -12,18 +12,20 @@ module.exports = {
     },
     plugins: [
         new CleanWebpackPlugin(),
-        new CopyWebpackPlugin([
-            {
-                from: "node_modules/node-notifier/vendor/snoreToast/snoretoast-x64.exe",
-                to: "../dist/snoretoast-x64.exe",
-                toType: "file"
-            },
-            {
-                from: "resources/bin/<APPNAME>-launcher.exe",
-                to: "../dist/<APPNAME>-launcher.exe",
-                toType: "file"
-            }
-        ])
+        new CopyWebpackPlugin({
+            patterns: [
+                {
+                    from: "node_modules/node-notifier/vendor/snoreToast/snoretoast-x64.exe",
+                    to: "../dist/snoretoast-x64.exe",
+                    toType: "file"
+                },
+                {
+                    from: "resources/bin/<APPNAME>-launcher.exe",
+                    to: "../dist/<APPNAME>-launcher.exe",
+                    toType: "file"
+                }
+            ]
+        })
     ],
     devtool: "source-map"
 };

--- a/templates/typescript/webpack.config.js
+++ b/templates/typescript/webpack.config.js
@@ -12,18 +12,20 @@ module.exports = {
     },
     plugins: [
         new CleanWebpackPlugin(),
-        new CopyWebpackPlugin([
-            {
-                from: "node_modules/node-notifier/vendor/snoreToast/snoretoast-x64.exe",
-                to: "../dist/snoretoast-x64.exe",
-                toType: "file"
-            },
-            {
-                from: "resources/bin/<APPNAME>-launcher.exe",
-                to: "../dist/<APPNAME>-launcher.exe",
-                toType: "file"
-            }
-        ])
+        new CopyWebpackPlugin({
+            patterns: [
+                {
+                    from: "node_modules/node-notifier/vendor/snoreToast/snoretoast-x64.exe",
+                    to: "../dist/snoretoast-x64.exe",
+                    toType: "file"
+                },
+                {
+                    from: "resources/bin/<APPNAME>-launcher.exe",
+                    to: "../dist/<APPNAME>-launcher.exe",
+                    toType: "file"
+                }
+            ]
+        })
     ],
     devtool: "source-map"
 };

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -8,5 +8,5 @@
         "lib": ["es6", "es2017"],
         "noEmit": true
     },
-    "include": ["./src/**/*", "./test/**/*", ".eslintrc.js"]
+    "include": ["./src/**/*", "./test/**/*", "./templates/**/*", ".eslintrc.js"]
 }


### PR DESCRIPTION
* Fix for breaking change of CopyWebpackPlugin:
  https://github.com/webpack-contrib/copy-webpack-plugin/releases/tag/v6.0.0
* Prepare version 3.2.0
* Fix eslint configuration to handle only .ts .js files
* ts-jest 26
* Fix javascript template (execfile import)