### PR TITLE
Separate action to 2 jobs

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,9 +10,7 @@ on:
 
 jobs:
   build:
-
     runs-on: windows-latest
-
     strategy:
       matrix:
         node-version: ['12', '14', '16']
@@ -38,8 +36,8 @@ jobs:
         CI: true
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
-    - name: Build and Test
-      run: npm run build
+    - name: Test
+      run: npm run test
       env:
         CI: true
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
@@ -50,8 +48,39 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
 
+  publish:
+    runs-on: windows-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    strategy:
+      matrix:
+        node-version: ['12']
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2.3.5
+
+    - name: Setup NodeJS
+      uses: actions/setup-node@v2.4.1
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: npm
+      env:
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
+    - name: Dependencies Install
+      run: npm ci
+      env:
+        CI: true
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
+    - name: Build
+      run: npm run build:no-test
+      env:
+        CI: true
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
     - name: Pre-Publish - install package globally
-      if: startsWith(github.ref, 'refs/tags/')
       run: |
         FOR /F "tokens=*" %%g IN ('node -e "console.log(require(""./package.json"").version)"') do (SET VERSION=%%g)
         npm i -g create-windowless-app-%VERSION%.tgz
@@ -60,7 +89,6 @@ jobs:
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
     - name: Pre-Publish - test package globally
-      if: startsWith(github.ref, 'refs/tags/')
       run: |
         create-windowless-app pre-commit-test-app
         cd pre-commit-test-app
@@ -70,14 +98,12 @@ jobs:
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
     - name: Publish
-      if: startsWith(github.ref, 'refs/tags/')
       run: npm publish
       env:
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
     - name: Release
       uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
       with:
         files: create-windowless-app-*.tgz
       env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "create-windowless-app",
-    "version": "7.9.2",
+    "version": "7.9.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "create-windowless-app",
-    "version": "7.9.2",
+    "version": "7.9.5",
     "description": "Create a windowless NodeJS app",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -10,7 +10,8 @@
     "scripts": {
         "prepare": "git config --get core.hookspath || husky install",
         "prebuild": "npm run test",
-        "build": "npm run tsc && npm run add-shebang && npm run package",
+        "build": "npm run build:no-test",
+        "build:no-test": "npm run tsc && npm run add-shebang && npm run package",
         "test": "npm run eslint && npm run type-check && npm run jest",
         "eslint": "eslint src/ test/ templates/",
         "eslint:fix": "npm run eslint -- --fix",


### PR DESCRIPTION
1. build, running on matrix of node versions
2. publish, depends on build, runs only when needed