### PR TITLE
Upgrade TypeScript to v6 and fix tsconfig types

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,4 @@
 save-exact=true
 package-lock=true
+fund=false
+min-release-age=14

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
                 "ts-jest": "29.4.9",
                 "ts-loader": "9.5.7",
                 "ts-node": "10.9.2",
-                "typescript": "5.9.3",
+                "typescript": "6.0.3",
                 "webpack": "5.105.4",
                 "webpack-cli": "6.0.1",
                 "winston": "3.19.0"
@@ -10860,9 +10860,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         "ts-jest": "29.4.9",
         "ts-loader": "9.5.7",
         "ts-node": "10.9.2",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "webpack": "5.105.4",
         "webpack-cli": "6.0.1",
         "winston": "3.19.0"

--- a/templates/typescript/tsconfig.json
+++ b/templates/typescript/tsconfig.json
@@ -10,7 +10,8 @@
         "forceConsistentCasingInFileNames": true,
         "allowJs": true,
         "noEmit": true,
-        "verbatimModuleSyntax": false
+        "verbatimModuleSyntax": false,
+        "types": ["node"]
     },
     "include": ["./src/**/*.ts", "./launcher/**/*.ts", "./utils/**/*.ts", "./webpack.config.ts"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,8 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "noEmit": false,
-        "outDir": "./dist"
+        "outDir": "./dist",
+        "rootDir": "./src"
     },
     "include": ["./src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
         "target": "es6",
         "noEmit": true,
         "verbatimModuleSyntax": false,
-        "types": ["node", "jest"]
+        "types": ["node", "jest"],
+        "rootDir": "."
     },
     "include": ["./src/**/*", "./test/**/*", "./integration_test/**/*", "./templates/**/*", "jest.config.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
         "allowJs": true,
         "target": "es6",
         "noEmit": true,
-        "verbatimModuleSyntax": false
+        "verbatimModuleSyntax": false,
+        "types": ["node", "jest"]
     },
     "include": ["./src/**/*", "./test/**/*", "./integration_test/**/*", "./templates/**/*", "jest.config.ts"]
 }


### PR DESCRIPTION
* Update typescript from 5.9.3 to 6.0.3 in package.json and package-lock.json
* Add explicit "types" arrays to tsconfig.json (node + jest) and template tsconfig (node) to fix type resolution under TS6
* Add fund=false and min-release-age=14 to .npmrc