### PR TITLE
Fix TypeScript template build config to set rootDir explicitly

### DIFF
--- a/templates/typescript/tsconfig.build.json
+++ b/templates/typescript/tsconfig.build.json
@@ -2,7 +2,8 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "noEmit": false,
-        "outDir": "./_compile"
+        "outDir": "./_compile",
+        "rootDir": "./src"
     },
     "include": ["./src/**/*"]
 }


### PR DESCRIPTION
* Add rootDir "./src" to tsconfig.build.json to prevent tsc from including files outside src/ during compilation