### PR TITLE
Replace inquirer with enquirer and bump version to 14.0.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,12 @@ The tool has two distinct roles: the **CLI tool itself** (in `src/`) and the **t
 
 ### CLI Source (`src/`)
 
-- **`index.ts`** — Entry point; calls `checkNodeVersion` then `createWindowlessApp`
-- **`cliParser.ts`** — Uses Node's built-in `util.parseArgs()`; handles `--interactive`, `--typescript`, `--icon`, `--verbose` flags
-- **`createWindowlessApp.ts`** — Main orchestration: validates name → creates dirs → generates `package.json` → copies templates → installs deps → compiles C# launcher
+- **`index.ts`** — Entry point; delegates to `main()`
+- **`main.ts`** — Top-level orchestration: `checkNodeRuntimeVersion` → `checkMsbuildInPath` → `createWindowlessApp(process.argv)`
+- **`checkNodeVersion.ts`** — Verifies the running Node.js meets the minimum version (>= 20.0)
+- **`cliParser.ts`** — Uses Node's built-in `util.parseArgs()`; handles `-v/--verbose`, `-i/--interactive`, `-t/--typescript` (default true) / `--no-typescript`, `-c/--icon <file>`, `--version`, `--help`. Routes to `interactiveMode()` when `--interactive` is set
+- **`interactive.ts`** — Enquirer-based interactive prompt flow (project name, icon, typescript, verbose); returns a `ProgramConfig`
+- **`createWindowlessApp.ts`** — Per-project orchestration: validates name → creates dirs → generates `package.json` → copies templates → installs deps → compiles C# launcher
 - **`files/fileManager.ts`** — Copies template files to the generated project; selects TypeScript or JavaScript variant
 - **`packageJson/packageJsonBuilder.ts`** — Generates `package.json` for the target project with webpack + SEA build scripts
 - **`dependencies/dependenciesManager.ts`** — Installs npm packages in generated project

--- a/README.md
+++ b/README.md
@@ -111,17 +111,22 @@ Then you can find in your my-app\dist folder the following files:
 ## create-windowless-app CLI
 
 ```
-create-windowless-app <project-directory> [options]
+Usage: create-windowless-app [projectName] [options]
+
+Arguments:
+  projectName            project name
 
 Options:
-    --no-typescript                 use javascript rather than typescript
-    --icon <icon>                   override default launcher icon file
-    --verbose                       print additional logs
-
-    --interactive                   interactive mode
-
-Only <project-directory> is required.
+  -v, --verbose          print additional logs
+  -i, --interactive      interactive mode
+  -t, --typescript       use typescript (default: true)
+      --no-typescript    disable typescript
+  -c, --icon <file>      override default launcher icon file
+      --version          Show version number
+      --help             Show help
 ```
+
+`projectName` is required unless `--interactive` is used.
 
 ## Why?
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "create-windowless-app",
-    "version": "13.0.8",
+    "version": "14.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "create-windowless-app",
-            "version": "13.0.8",
+            "version": "14.0.0",
             "license": "MIT",
             "dependencies": {
                 "chalk": "4.1.2",
-                "inquirer": "11.1.0",
+                "enquirer": "2.4.1",
                 "validate-npm-package-name": "7.0.2"
             },
             "bin": {
@@ -29,7 +29,6 @@
                 "@types/winston": "2.4.4",
                 "@typescript-eslint/eslint-plugin": "8.59.2",
                 "@typescript-eslint/parser": "8.59.2",
-                "add-shebang": "0.1.0",
                 "copy-webpack-plugin": "14.0.0",
                 "cross-env": "10.1.0",
                 "eslint": "9.39.4",
@@ -920,228 +919,6 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
-        "node_modules/@inquirer/checkbox": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-3.0.1.tgz",
-            "integrity": "sha512-0hm2nrToWUdD6/UHnel/UKGdk1//ke5zGUpHIvk5ZWmaKezlGxZkOJXNSWsdxO/rEqTkbB3lNC2J6nBElV2aAQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^9.2.1",
-                "@inquirer/figures": "^1.0.6",
-                "@inquirer/type": "^2.0.0",
-                "ansi-escapes": "^4.3.2",
-                "yoctocolors-cjs": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@inquirer/confirm": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-4.0.1.tgz",
-            "integrity": "sha512-46yL28o2NJ9doViqOy0VDcoTzng7rAb6yPQKU7VDLqkmbCaH4JqK4yk4XqlzNWy9PVC5pG1ZUXPBQv+VqnYs2w==",
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^9.2.1",
-                "@inquirer/type": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@inquirer/core": {
-            "version": "9.2.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
-            "integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/figures": "^1.0.6",
-                "@inquirer/type": "^2.0.0",
-                "@types/mute-stream": "^0.0.4",
-                "@types/node": "^22.5.5",
-                "@types/wrap-ansi": "^3.0.0",
-                "ansi-escapes": "^4.3.2",
-                "cli-width": "^4.1.0",
-                "mute-stream": "^1.0.0",
-                "signal-exit": "^4.1.0",
-                "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^6.2.0",
-                "yoctocolors-cjs": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@inquirer/core/node_modules/@types/node": {
-            "version": "22.19.15",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-            "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": "~6.21.0"
-            }
-        },
-        "node_modules/@inquirer/core/node_modules/undici-types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-            "license": "MIT"
-        },
-        "node_modules/@inquirer/editor": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-3.0.1.tgz",
-            "integrity": "sha512-VA96GPFaSOVudjKFraokEEmUQg/Lub6OXvbIEZU1SDCmBzRkHGhxoFAVaF30nyiB4m5cEbDgiI2QRacXZ2hw9Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^9.2.1",
-                "@inquirer/type": "^2.0.0",
-                "external-editor": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@inquirer/expand": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-3.0.1.tgz",
-            "integrity": "sha512-ToG8d6RIbnVpbdPdiN7BCxZGiHOTomOX94C2FaT5KOHupV40tKEDozp12res6cMIfRKrXLJyexAZhWVHgbALSQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^9.2.1",
-                "@inquirer/type": "^2.0.0",
-                "yoctocolors-cjs": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@inquirer/figures": {
-            "version": "1.0.15",
-            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-            "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@inquirer/input": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-3.0.1.tgz",
-            "integrity": "sha512-BDuPBmpvi8eMCxqC5iacloWqv+5tQSJlUafYWUe31ow1BVXjW2a5qe3dh4X/Z25Wp22RwvcaLCc2siHobEOfzg==",
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^9.2.1",
-                "@inquirer/type": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@inquirer/number": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-2.0.1.tgz",
-            "integrity": "sha512-QpR8jPhRjSmlr/mD2cw3IR8HRO7lSVOnqUvQa8scv1Lsr3xoAMMworcYW3J13z3ppjBFBD2ef1Ci6AE5Qn8goQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^9.2.1",
-                "@inquirer/type": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@inquirer/password": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-3.0.1.tgz",
-            "integrity": "sha512-haoeEPUisD1NeE2IanLOiFr4wcTXGWrBOyAyPZi1FfLJuXOzNmxCJPgUrGYKVh+Y8hfGJenIfz5Wb/DkE9KkMQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^9.2.1",
-                "@inquirer/type": "^2.0.0",
-                "ansi-escapes": "^4.3.2"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@inquirer/prompts": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-6.0.1.tgz",
-            "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/checkbox": "^3.0.1",
-                "@inquirer/confirm": "^4.0.1",
-                "@inquirer/editor": "^3.0.1",
-                "@inquirer/expand": "^3.0.1",
-                "@inquirer/input": "^3.0.1",
-                "@inquirer/number": "^2.0.1",
-                "@inquirer/password": "^3.0.1",
-                "@inquirer/rawlist": "^3.0.1",
-                "@inquirer/search": "^2.0.1",
-                "@inquirer/select": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@inquirer/rawlist": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-3.0.1.tgz",
-            "integrity": "sha512-VgRtFIwZInUzTiPLSfDXK5jLrnpkuSOh1ctfaoygKAdPqjcjKYmGh6sCY1pb0aGnCGsmhUxoqLDUAU0ud+lGXQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^9.2.1",
-                "@inquirer/type": "^2.0.0",
-                "yoctocolors-cjs": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@inquirer/search": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-2.0.1.tgz",
-            "integrity": "sha512-r5hBKZk3g5MkIzLVoSgE4evypGqtOannnB3PKTG9NRZxyFRKcfzrdxXXPcoJQsxJPzvdSU2Rn7pB7lw0GCmGAg==",
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^9.2.1",
-                "@inquirer/figures": "^1.0.6",
-                "@inquirer/type": "^2.0.0",
-                "yoctocolors-cjs": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@inquirer/select": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-3.0.1.tgz",
-            "integrity": "sha512-lUDGUxPhdWMkN/fHy1Lk7pF3nK1fh/gqeyWXmctefhxLYxlDsc7vsPBEpxrfVGDsVdyYJsiJoD4bJ1b623cV1Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^9.2.1",
-                "@inquirer/figures": "^1.0.6",
-                "@inquirer/type": "^2.0.0",
-                "ansi-escapes": "^4.3.2",
-                "yoctocolors-cjs": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@inquirer/type": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
-            "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
-            "license": "MIT",
-            "dependencies": {
-                "mute-stream": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
             "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -2003,19 +1780,11 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/mute-stream": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
-            "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/node": {
             "version": "24.12.4",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
             "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~7.16.0"
@@ -2062,12 +1831,6 @@
             "dependencies": {
                 "winston": "*"
             }
-        },
-        "node_modules/@types/wrap-ansi": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
-            "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
-            "license": "MIT"
         },
         "node_modules/@types/yargs": {
             "version": "17.0.35",
@@ -2272,29 +2035,6 @@
             },
             "peerDependencies": {
                 "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -2892,20 +2632,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/add-shebang": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/add-shebang/-/add-shebang-0.1.0.tgz",
-            "integrity": "sha512-CDyCOkCQzM7T1QtuaK6DJzyoypuqCsYRwg20bwyM4lCTs66PUitG8bBk+6/W0r/pDHBoq3s4Vznkarlgj8i/3w==",
-            "deprecated": "Package no longer maintained.",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "prepend-file": "^1.3.1"
-            },
-            "bin": {
-                "add-shebang": "dist/cli.js"
-            }
-        },
         "node_modules/aggregate-error": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -2979,10 +2705,20 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/ansi-colors": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/ansi-escapes": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
             "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "type-fest": "^0.21.3"
@@ -3334,11 +3070,14 @@
             }
         },
         "node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
         },
         "node_modules/baseline-browser-mapping": {
             "version": "2.10.12",
@@ -3354,14 +3093,16 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -3620,12 +3361,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/chardet": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-            "license": "MIT"
-        },
         "node_modules/check-more-types": {
             "version": "2.24.0",
             "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
@@ -3756,15 +3491,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
-        "node_modules/cli-width": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-            "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-            "license": "ISC",
-            "engines": {
-                "node": ">= 12"
             }
         },
         "node_modules/cliui": {
@@ -3957,13 +3683,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
             "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/concat-map": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true,
             "license": "MIT"
         },
@@ -4305,6 +4024,19 @@
             },
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/enquirer": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+            "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-colors": "^4.1.1",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8.6"
             }
         },
         "node_modules/envinfo": {
@@ -5109,20 +4841,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/external-editor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-            "license": "MIT",
-            "dependencies": {
-                "chardet": "^0.7.0",
-                "iconv-lite": "^0.4.24",
-                "tmp": "^0.0.33"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5626,16 +5344,6 @@
             "dev": true,
             "license": "BSD-2-Clause"
         },
-        "node_modules/glob/node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
         "node_modules/glob/node_modules/minimatch": {
             "version": "9.0.9",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -5901,18 +5609,6 @@
                 "url": "https://github.com/sponsors/typicode"
             }
         },
-        "node_modules/iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5998,25 +5694,6 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/inquirer": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-11.1.0.tgz",
-            "integrity": "sha512-CmLAZT65GG/v30c+D2Fk8+ceP6pxD6RL+hIUOWAltCmeyEqWYwqu9v76q03OvjyZ3AB0C1Ala2stn1z/rMqGEw==",
-            "license": "MIT",
-            "dependencies": {
-                "@inquirer/core": "^9.2.1",
-                "@inquirer/prompts": "^6.0.1",
-                "@inquirer/type": "^2.0.0",
-                "@types/mute-stream": "^0.0.4",
-                "ansi-escapes": "^4.3.2",
-                "mute-stream": "^1.0.0",
-                "run-async": "^3.0.0",
-                "rxjs": "^7.8.1"
-            },
-            "engines": {
-                "node": ">=18"
-            }
         },
         "node_modules/internal-slot": {
             "version": "1.1.0",
@@ -7951,15 +7628,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/mute-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-            "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-            "license": "ISC",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
         "node_modules/napi-postinstall": {
             "version": "0.3.4",
             "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
@@ -8095,29 +7763,6 @@
             },
             "engines": {
                 "node": "20 || >=22"
-            }
-        },
-        "node_modules/nyc/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/nyc/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/nyc/node_modules/cliui": {
@@ -8556,15 +8201,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/own-keys": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -8897,32 +8533,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/prepend-file": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/prepend-file/-/prepend-file-1.3.1.tgz",
-            "integrity": "sha512-NFKEPDka08hvbVUZOu5JtFKJuWkZhWOJ/Odz6tsMlHWDtg6aUncrbu/BV3uTPRNa5T69SzbWIucg11e2kr4vBA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tmp": "0.0.31"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/prepend-file/node_modules/tmp": {
-            "version": "0.0.31",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
-            "integrity": "sha512-lfyEfOppKvWNeId5CArFLwgwef+iCnbEIy0JWYf1httIEXnx4ndL4Dr1adw7hPgeQfSlTbc/gqn6iaKcROpw5Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "os-tmpdir": "~1.0.1"
-            },
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/prettier": {
@@ -9279,29 +8889,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/rimraf/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
         "node_modules/rimraf/node_modules/glob": {
             "version": "13.0.6",
             "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -9361,24 +8948,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/run-async": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-            "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.12.0"
-            }
-        },
-        "node_modules/rxjs": {
-            "version": "7.8.2",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-            "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.1.0"
             }
         },
         "node_modules/safe-array-concat": {
@@ -9476,12 +9045,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "license": "MIT"
         },
         "node_modules/schema-utils": {
             "version": "4.3.3",
@@ -9742,6 +9305,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=14"
@@ -10402,15 +9966,13 @@
             }
         },
         "node_modules/tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+            "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "os-tmpdir": "~1.0.2"
-            },
             "engines": {
-                "node": ">=0.6.0"
+                "node": ">=14.14"
             }
         },
         "node_modules/tmp-promise": {
@@ -10421,16 +9983,6 @@
             "license": "MIT",
             "dependencies": {
                 "tmp": "^0.2.0"
-            }
-        },
-        "node_modules/tmp-promise/node_modules/tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.14"
             }
         },
         "node_modules/tmpl": {
@@ -10657,7 +10209,9 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -10686,6 +10240,7 @@
             "version": "0.21.3",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
             "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=10"
@@ -10833,6 +10388,7 @@
             "version": "7.16.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
             "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/unrs-resolver": {
@@ -10919,13 +10475,17 @@
             "license": "MIT"
         },
         "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+            "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
             "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist-node/bin/uuid"
             }
         },
         "node_modules/v8-compile-cache-lib": {
@@ -11299,6 +10859,7 @@
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
             "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
@@ -11364,12 +10925,14 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -11379,6 +10942,7 @@
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
@@ -11523,18 +11087,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/yoctocolors-cjs": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-            "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "create-windowless-app",
-    "version": "13.0.8",
+    "version": "14.0.0",
     "description": "Create a windowless NodeJS app",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -24,7 +24,7 @@
         "prettier": "prettier --write *.json templates/**/*.json",
         "pretsc": "rimraf dist",
         "tsc": "tsc --build tsconfig.build.json",
-        "add-shebang": "add-shebang",
+        "add-shebang": "node -r ts-node/register/transpile-only scripts/add-shebang.ts",
         "start": "ts-node src/index.ts",
         "start:help": "npm run start -- --help",
         "package": "npm pack",
@@ -68,7 +68,6 @@
         "@types/winston": "2.4.4",
         "@typescript-eslint/eslint-plugin": "8.59.2",
         "@typescript-eslint/parser": "8.59.2",
-        "add-shebang": "0.1.0",
         "copy-webpack-plugin": "14.0.0",
         "cross-env": "10.1.0",
         "eslint": "9.39.4",
@@ -100,8 +99,12 @@
     },
     "dependencies": {
         "chalk": "4.1.2",
-        "inquirer": "11.1.0",
+        "enquirer": "2.4.1",
         "validate-npm-package-name": "7.0.2"
+    },
+    "overrides": {
+        "uuid": "14.0.0",
+        "brace-expansion": "5.0.6"
     },
     "lint-staged": {
         "*.(ts|js)": [

--- a/scripts/add-shebang.ts
+++ b/scripts/add-shebang.ts
@@ -1,0 +1,26 @@
+import { readFile, writeFile } from "fs/promises";
+
+const SHEBANG = "#!/usr/bin/env node\n";
+
+const collectBinFiles = (bin: unknown): string[] => {
+    if (typeof bin === "string") return [bin];
+    if (Array.isArray(bin)) return bin as string[];
+    if (bin && typeof bin === "object") return Object.values(bin as Record<string, string>);
+    return [];
+};
+
+const addShebangToFile = async (file: string): Promise<void> => {
+    const content = await readFile(file, "utf8");
+    await writeFile(file, SHEBANG + content, "utf8");
+};
+
+const addShebang = async (): Promise<void> => {
+    const packageJson = JSON.parse(await readFile("./package.json", "utf8"));
+    const files = collectBinFiles(packageJson.bin);
+    await Promise.all(files.map(addShebangToFile));
+};
+
+addShebang().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -1,9 +1,9 @@
-import inquirer from "inquirer";
+import Enquirer from "enquirer";
 import type { ProgramConfig } from "./cliParser";
 import { validateProjectNameInput } from "./validation";
 
 export const interactiveMode = (): Promise<ProgramConfig> => {
-    return inquirer.prompt([
+    return Enquirer.prompt<ProgramConfig>([
         {
             type: "input",
             message: "Project Name:",
@@ -19,13 +19,13 @@ export const interactiveMode = (): Promise<ProgramConfig> => {
             type: "confirm",
             message: "TypeScript:",
             name: "typescript",
-            default: true
+            initial: true
         },
         {
             type: "confirm",
             message: "Verbose:",
             name: "verbose",
-            default: false
+            initial: false
         }
     ]);
 };

--- a/test/cliParser.test.ts
+++ b/test/cliParser.test.ts
@@ -2,7 +2,7 @@ import type { ProgramConfig } from "../src/cliParser";
 import { parseCommand } from "../src/cliParser";
 import * as interactive from "../src/interactive";
 import { randomUUID as uuid } from "crypto";
-import inquirer from "inquirer";
+import Enquirer from "enquirer";
 import * as path from "path";
 
 describe("Test cliParser", () => {
@@ -119,13 +119,12 @@ describe("Test cliParser", () => {
             expect(icon).toBeUndefined();
         });
 
-        it("should call inquirer in interactive mode", async () => {
-            // @ts-expect-error -- prompt has complex generics; mock returns empty object
-            jest.spyOn(inquirer, "prompt").mockImplementation(async () => ({}));
+        it("should call enquirer in interactive mode", async () => {
+            jest.spyOn(Enquirer, "prompt").mockImplementation(async () => ({}));
 
             await parseCommand(["node.exe", "dummy.ts", "--interactive"]);
 
-            expect(inquirer.prompt).toHaveBeenCalled();
+            expect(Enquirer.prompt).toHaveBeenCalled();
         });
     });
 });

--- a/test/createWindowlessApp.test.ts
+++ b/test/createWindowlessApp.test.ts
@@ -12,7 +12,9 @@ jest.mock("child_process", () => ({
 
 const mockFsRmSync = jest.fn();
 jest.mock("fs", () => {
+    const actualFs = jest.requireActual("fs");
     return {
+        ...actualFs,
         existsSync: jest.fn(() => true),
         lstatSync: jest.fn(() => ({ isDirectory: () => true })),
         mkdirSync: jest.fn(),
@@ -22,6 +24,7 @@ jest.mock("fs", () => {
         readFileSync: jest.fn(() => "{}"),
         copyFileSync: jest.fn(),
         promises: {
+            ...actualFs.promises,
             access: jest.fn(() => Promise.resolve())
         }
     };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
         "types": ["node", "jest"],
         "rootDir": "."
     },
-    "include": ["./src/**/*", "./test/**/*", "./integration_test/**/*", "./templates/**/*", "jest.config.ts"]
+    "include": ["./src/**/*", "./test/**/*", "./integration_test/**/*", "./templates/**/*", "./scripts/**/*", "jest.config.ts"]
 }


### PR DESCRIPTION
* Replace the `inquirer` dependency with `enquirer` in the interactive prompt flow.
* Update the interactive-mode test. The test now mocks `Enquirer.prompt` instead of `inquirer.prompt`.
* Bump the package version to 14.0.0.
* Replace the `add-shebang` npm package with a custom script at `scripts/add-shebang.ts`.
* Update the `add-shebang` npm script to run the new script through `ts-node`.
* Add `overrides` entries for `uuid` and `brace-expansion` in package.json.
* Pin `brace-expansion` per `minimatch` major. Version 5 changes the CommonJS export shape. A blanket override breaks `minimatch` 3 and 9.
* Include `scripts/**/*` in the TypeScript include list in tsconfig.json.
* Update devDependencies to their latest patch and minor versions.
* Update the `fs` mock in `createWindowlessApp.test.ts`. The mock now spreads `jest.requireActual("fs")` for `promises`.
* Update CLAUDE.md and README.md to describe the current CLI structure and help text.